### PR TITLE
Fix docs page: strip .md extension from slug and properly render content

### DIFF
--- a/apps/web/src/pages/docs/[slug].astro
+++ b/apps/web/src/pages/docs/[slug].astro
@@ -5,13 +5,13 @@ import { getDocs } from '../../lib/docs';
 export async function getStaticPaths() {
   const docs = await getDocs();
   return docs.map((doc) => ({
-    params: { slug: doc.id },
+    params: { slug: doc.id.replace('.md', '') },
     props: { doc },
   }));
 }
 
 const { doc } = Astro.props;
-const Content = doc.Content;
+const { Content } = await doc.render();
 ---
 
 <DocsLayout title={`${doc.data.title} | Adamosophy`}>


### PR DESCRIPTION
This fixes the build error where directories were being created with .md in the name.

- Remove .md extension from doc.id when generating static paths to create clean URLs
- Use doc.render() to properly get the Content component for Astro pages